### PR TITLE
Leave Hash alone. Don't include Hashie::HashExtensions in Hash.

### DIFF
--- a/lib/createsend.rb
+++ b/lib/createsend.rb
@@ -2,7 +2,6 @@ require 'cgi'
 require 'uri'
 require 'httparty'
 require 'hashie'
-Hash.send :include, Hashie::HashExtensions
 
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)


### PR DESCRIPTION
Including the `Hashie` extensions to `Hash` can lead to all sorts of unwanted behavior - eg. colliding with other gems or application specific extensions to `Hash`. There's no reason to force the extensions to `Hash`, as they're not even used in the gem.

All tests pass.
