### PR TITLE
Added support for getting an external session login URL

### DIFF
--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -183,6 +183,33 @@ module CreateSend
       Hashie::Mash.new(response)
     end
 
+    # Get a URL which initiates a new external session for the user with the
+    # given email.
+    # Full details: http://www.campaignmonitor.com/api/account/#single_sign_on
+    #
+    # email         - The email address of the Campaign Monitor user for whom
+    #                 the login session should be created.
+    # chrome        - Which 'chrome' to display - Must be either "all",
+    #                 "tabs", or "none".
+    # url           - The URL to display once logged in. e.g. "/subscribers/"
+    # integrator_id - The integrator ID. You need to contact Campaign Monitor
+    #                 support to get an integrator ID.
+    # client_id     - The Client ID of the client which should be active once
+    #                 logged in to the Campaign Monitor account.
+    #
+    # Returns An object containing a single field SessionUrl which represents
+    # the URL to initiate the external Campaign Monitor session.
+    def external_session_url(email, chrome, url, integrator_id, client_id)
+      options = { :body => {
+        :Email => email,
+        :Chrome => chrome,
+        :Url => url,
+        :IntegratorID => integrator_id,
+        :ClientID => client_id }.to_json }
+      response = put("/externalsession.json", options)
+      Hashie::Mash.new(response)
+    end
+
     def get(*args)
       args = add_auth_details_to_options(args)
       handle_response CreateSend.get(*args)

--- a/test/createsend_test.rb
+++ b/test/createsend_test.rb
@@ -261,6 +261,17 @@ class CreateSendTest < Test::Unit::TestCase
       result.EmailAddress.should == 'admin@blackhole.com'
     end
 
+    should "get an external session url" do
+      email = "exammple@example.com"
+      chrome = "None"
+      url = "/subscribers"
+      integrator_id = "qw989q8wud98qwyd"
+      client_id = "9q8uw9d8u9wud"
+      stub_put(@auth, "externalsession.json", "external_session.json")
+      result = @cs.external_session_url email, chrome, url, integrator_id, client_id
+      result.SessionUrl.should == "https://external1.createsend.com/cd/create/ABCDEF12/DEADBEEF?url=FEEDDAD1"
+    end
+
   end
 
   context "when the CreateSend API responds with an error" do

--- a/test/fixtures/external_session.json
+++ b/test/fixtures/external_session.json
@@ -1,0 +1,3 @@
+{
+  "SessionUrl": "https://external1.createsend.com/cd/create/ABCDEF12/DEADBEEF?url=FEEDDAD1"
+}


### PR DESCRIPTION
Added support for the feature which allows an API caller to get a URL which initiates a login for an external Campaign Monitor session.

API docs: http://www.campaignmonitor.com/api/account/#single_sign_on
