### PR TITLE
User-Agent header improvements

### DIFF
--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -6,6 +6,8 @@ require 'json'
 
 module CreateSend
 
+  USER_AGENT_STRING = "createsend-ruby-#{VERSION}-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}-#{RUBY_PLATFORM}"
+
   # Represents a CreateSend API error. Contains specific data about the error.
   class CreateSendError < StandardError
     attr_reader :data
@@ -48,10 +50,10 @@ module CreateSend
     # CreateSend::CreateSend make API calls.
     #
     # user_agent - The user agent string to use in the User-Agent header when
-    #              instances of this class make API calls. If set to nil, a
-    #              default user agent string will be used.
+    #              instances of this class make API calls. If set to nil, the
+    #              default value of CreateSend::USER_AGENT_STRING will be used.
     def self.user_agent(user_agent)
-      headers({'User-Agent' => user_agent || "createsend-ruby-#{VERSION}"})
+      headers({'User-Agent' => user_agent || USER_AGENT_STRING})
     end
 
     # Get the authorization URL for your application, given the application's
@@ -108,7 +110,7 @@ module CreateSend
     @@oauth_base_uri = "https://api.createsend.com/oauth"
     @@oauth_token_uri = "#{@@oauth_base_uri}/token"
     headers({
-      'User-Agent' => "createsend-ruby-#{VERSION}",
+      'User-Agent' => USER_AGENT_STRING,
       'Content-Type' => 'application/json; charset=utf-8',
       'Accept-Encoding' => 'gzip, deflate' })
     base_uri @@base_uri

--- a/test/createsend_test.rb
+++ b/test/createsend_test.rb
@@ -197,9 +197,9 @@ class CreateSendTest < Test::Unit::TestCase
       @cs = CreateSend::CreateSend.new @auth
     end
 
-    should "include the CreateSend module VERSION constant as part of the user agent when making a call" do
-      # This test is done to ensure that the version from HTTParty isn't included instead
-      assert CreateSend::CreateSend.headers["User-Agent"] == "createsend-ruby-#{CreateSend::VERSION}"
+    should "include the correct user agent string when making a call" do
+      CreateSend::CreateSend.headers["User-Agent"].should ==
+        "createsend-ruby-#{CreateSend::VERSION}-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}-#{RUBY_PLATFORM}"
       stub_get(@auth, "clients.json", "clients.json")
       clients = @cs.clients
       clients.size.should == 2
@@ -207,7 +207,7 @@ class CreateSendTest < Test::Unit::TestCase
 
     should "allow a custom user agent string to be set when making a call" do
       CreateSend::CreateSend.user_agent "custom user agent"
-      assert CreateSend::CreateSend.headers["User-Agent"] == "custom user agent"
+      CreateSend::CreateSend.headers["User-Agent"].should == "custom user agent"
       stub_get(@auth, "clients.json", "clients.json")
       clients = @cs.clients
       clients.size.should == 2


### PR DESCRIPTION
1. Currently the default User-Agent header is of the form `createsend-ruby-{version}`. Modify this to include Ruby version and platform information: `createsend-ruby-{version}-{RUBY_VERSION}-p{RUBY_PATCHLEVEL}-{RUBY_PLATFORM}`.
   So the default user agent would look more like:
   
   ``` ruby
   "createsend-ruby-3.2.0-1.9.3-p392-x86_64-darwin12.3.0"
   ```
2. Allow the default User-Agent header to be overridden by doing this:
   
   ``` ruby
   CreateSend::CreateSend.user_agent "my custom user agent"
   ```
