### PR TITLE
Testing against ruby-head on Travis is a bit of a joke.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - jruby-19mode
   - rbx-18mode
   - rbx-19mode
-  - ruby-head
   - jruby-head
   - 1.8.7
   - ree


### PR DESCRIPTION
Travis CI has recommended adding all ruby-head builds to an allow_failures config:

https://github.com/travis-ci/travis-ci/issues/1195#issuecomment-20160541

I'd rather just leave it out of the config.
