### PR TITLE
Bump Hashie dependency to < 3.4

### DIFF
--- a/createsend.gemspec
+++ b/createsend.gemspec
@@ -5,7 +5,7 @@ require File.expand_path('lib/createsend/version')
 
 Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '>= 0'
-  s.add_runtime_dependency 'hashie', ['>= 1.2', '< 3']
+  s.add_runtime_dependency 'hashie', ['>= 1.2', '< 3.4']
   s.add_runtime_dependency 'httparty', '~> 0.10'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'fakeweb', '~> 1.3'


### PR DESCRIPTION
Increase the version dependency with Hashie to < 3.4

Background is that we have a project with Hashie requirements > 3 and trying to use this gem causes a bundle error.

Run the tests and everything was green.
