### PR TITLE
Bump and simplify hashie dependency

### DIFF
--- a/createsend.gemspec
+++ b/createsend.gemspec
@@ -5,7 +5,7 @@ require File.expand_path('lib/createsend/version')
 
 Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '>= 0'
-  s.add_runtime_dependency 'hashie', ['>= 1.2', '~> 3.0']
+  s.add_runtime_dependency 'hashie', '~> 3.0'
   s.add_runtime_dependency 'httparty', '~> 0.10'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'fakeweb', '~> 1.3'


### PR DESCRIPTION
Simplifies and bumps the [hashie](https://rubygems.org/gems/hashie) dependency to `~> 3.0`

Preferred over https://github.com/campaignmonitor/createsend-ruby/pull/37
