### PR TITLE
fix http encoding

### DIFF
--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -114,8 +114,8 @@ module CreateSend
     @@oauth_token_uri = "#{@@oauth_base_uri}/token"
     headers({
       'User-Agent' => USER_AGENT_STRING,
-      'Content-Type' => 'application/json; charset=utf-8',
-      'Accept-Encoding' => 'gzip, deflate' })
+      'Content-Type' => 'application/json; charset=utf-8'
+    })
     base_uri @@base_uri
 
     # Authenticate using either OAuth or an API key.


### PR DESCRIPTION
Net::HTTP automatically adds Accept-Encoding for compression of response bodies and automatically decompresses gzip and deflate responses unless a Range header was sent.

Compression can be disabled through the Accept-Encoding: identity header.
So, now if you sent this header - you disable this decoding.
https://github.com/jnunemaker/httparty/blob/master/spec/httparty/request_spec.rb#L1232-L1248

Just need to remove header
