### PR TITLE
specify ruby 2.0 or better as required in the gemspec

### DIFF
--- a/createsend.gemspec
+++ b/createsend.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.version = CreateSend::VERSION
   s.platform = Gem::Platform::RUBY
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = ">=2.0"
   s.licenses = ['MIT']
 end


### PR DESCRIPTION
The README says only version 2.0 or better is supported, and the travis config runs builds on 2.0 and up.

By aligning the gemspec with both those locations, installers of the gem will be clearly notified when they're running an unsupported ruby version.