### PR TITLE
Remove GZip compression

### DIFF
--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -114,8 +114,7 @@ module CreateSend
     @@oauth_token_uri = "#{@@oauth_base_uri}/token"
     headers({
       'User-Agent' => USER_AGENT_STRING,
-      'Content-Type' => 'application/json; charset=utf-8',
-      'Accept-Encoding' => 'gzip, deflate' })
+      'Content-Type' => 'application/json; charset=utf-8'})
     base_uri @@base_uri
 
     # Authenticate using either OAuth or an API key.


### PR DESCRIPTION
## Problem

GZip content not being unzipped

As referenced in these issues: https://github.com/campaignmonitor/createsend-ruby/issues/47, https://github.com/campaignmonitor/createsend-ruby/issues/58,

## Solution

Remove `'Accept-Encoding' => 'gzip, deflate'` which will allow things to be GZipped (Net::HTTP handles this automatically) but will allow automatic unzipping.


There seem to be many forks on the repo which do the same thing as mine.