### PR TITLE
EL-279 Add v3.3 support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # createsend-ruby history
 
-## v6.0.0 - 22 Nov, 2021
+## v6.0.0 - 15 Dec, 2021
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * Breaking: 'client.campaigns' now returned an object to support pagination (use .Results to ge the array of campaigns)
 * Added 'Tags' as another field that is returned in 'client.scheduled', 'client.drafts' and 'client.campaigns'
@@ -8,6 +8,14 @@
 * Add new support for 'client.tags' endpoint (ie: getting list of tags for the client)
 * Add support for pagination, filtering and sorting to 'client.campaigns' endpoint
 * Bump `rake` to `~> 12.3.3`
+* Adding support for returning ListJoinedDate for each subscriber. 
+  * List.Active()
+  * List.Bounced()
+  * List.Unsubscribed()
+  * List.Unconfirmed()
+  * List.Deleted()
+  * Segment.Subscribers()
+  * Subscriber.Get()
 
 ## v5.1.1 - 8 Oct, 2021
 * increased default timeout for HTTP requests to 120secs

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # createsend-ruby history
 
+## v6.0.0 - 22 Nov, 2021
+* Upgrades to Createsend API v3.3 which includes new breaking changes
+* Breaking: 'client.campaigns' now returned an object to support pagination (use .Results to ge the array of campaigns)
+* Added 'Tags' as another field that is returned in 'client.scheduled', 'client.drafts' and 'client.campaigns'
+* Added 'Name' as another field that is returned in 'campaign.summary'
+* Add new support for 'client.tags' endpoint (ie: getting list of tags for the client)
+* Add support for pagination, filtering and sorting to 'client.campaigns' endpoint
+* Bump `rake` to `~> 12.3.3`
+
 ## v5.1.1 - 8 Oct, 2021
 * increased default timeout for HTTP requests to 120secs
 

--- a/README.md
+++ b/README.md
@@ -132,20 +132,9 @@ clients = cs.clients
 clients.each do |cl|
   p "Client: #{cl.Name}"
   client = CreateSend::Client.new auth, cl.ClientID
-  campaigns = []
-  page_number = 1
-  loop do
-      page = @client.campaigns(page_number)
-      page_number += 1
-      campaigns.concat(page.Results)
-      if page.PageNumber == page.NumberOfPages
-          break
-      end
-  end
   p "- Campaigns:"
-    campaigns.each do |cm|
-      p "  - #{cm.Subject}"
-    end
+  client.drafts.each do |cm|
+    p "  - #{cm.Subject}"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ clients.each do |cl|
   campaigns = []
   page_number = 1
   loop do
-      page = @client.campaigns(page_number, 1000, 'desc', '', '', '')
+      page = @client.campaigns(page_number)
       page_number += 1
       campaigns.concat(page.Results)
       if page.PageNumber == page.NumberOfPages

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ clients.each do |cl|
   p "Client: #{cl.Name}"
   client = CreateSend::Client.new auth, cl.ClientID
   p "- Campaigns:"
-  client.campaigns.each do |cm|
+  client.campaigns.Results.each do |cm|
     p "  - #{cm.Subject}"
   end
 end

--- a/README.md
+++ b/README.md
@@ -132,9 +132,20 @@ clients = cs.clients
 clients.each do |cl|
   p "Client: #{cl.Name}"
   client = CreateSend::Client.new auth, cl.ClientID
+  campaigns = []
+  page_number = 1
+  loop do
+      page = @client.campaigns(page_number, 1000, 'desc', '', '', '')
+      page_number += 1
+      campaigns.concat(page.Results)
+      if page.PageNumber == page.NumberOfPages
+          break
+      end
+  end
   p "- Campaigns:"
-  client.campaigns.Results.each do |cm|
-    p "  - #{cm.Subject}"
+    campaigns.each do |cm|
+      p "  - #{cm.Subject}"
+    end
   end
 end
 ```

--- a/createsend.gemspec
+++ b/createsend.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '>= 1.0'
   s.add_runtime_dependency 'hashie', '~> 3.0'
   s.add_runtime_dependency 'httparty', '~> 0.14'
-  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rake', '~> 12.3.3'
   s.add_development_dependency 'fakeweb', '~> 1.3'
   s.add_development_dependency 'jnunemaker-matchy', '~> 0.4'
   s.add_development_dependency 'shoulda-context', '~> 1.2'

--- a/lib/createsend/client.rb
+++ b/lib/createsend/client.rb
@@ -25,9 +25,19 @@ module CreateSend
     end
 
     # Gets the sent campaigns belonging to this client.
-    def campaigns
-      response = get 'campaigns'
-      response.map{|item| Hashie::Mash.new(item)}
+    def campaigns(page=1, page_size=1000, order_direction="desc",
+      sent_from_date='', sent_to_date='', tags='')
+      options = { :query => {
+        :page => page,
+        :pagesize => page_size,
+        :orderdirection => order_direction,
+        :sentfromdate => sent_from_date,
+        :senttodate => sent_to_date,
+        :tags => tags
+      }}
+
+      response = get 'campaigns', options
+      Hashie::Mash.new(response)
     end
 
     # Gets the currently scheduled campaigns belonging to this client.
@@ -39,6 +49,12 @@ module CreateSend
     # Gets the draft campaigns belonging to this client.
     def drafts
       response = get 'drafts'
+      response.map{|item| Hashie::Mash.new(item)}
+    end
+
+    # Gets all the tags belonging to this client.
+    def tags
+      response = get 'tags'
       response.map{|item| Hashie::Mash.new(item)}
     end
 

--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -111,7 +111,7 @@ module CreateSend
       end
     end
 
-    @@base_uri = "https://api.createsend.com/api/v3.2"
+    @@base_uri = "https://api.createsend.com/api/v3.3"
     @@oauth_base_uri = "https://api.createsend.com/oauth"
     @@oauth_token_uri = "#{@@oauth_base_uri}/token"
     headers({

--- a/lib/createsend/version.rb
+++ b/lib/createsend/version.rb
@@ -1,3 +1,3 @@
 module CreateSend
-  VERSION = "5.1.1" unless defined?(CreateSend::VERSION)
+  VERSION = "5.2.0" unless defined?(CreateSend::VERSION)
 end

--- a/lib/createsend/version.rb
+++ b/lib/createsend/version.rb
@@ -1,3 +1,3 @@
 module CreateSend
-  VERSION = "5.2.0" unless defined?(CreateSend::VERSION)
+  VERSION = "6.0.0" unless defined?(CreateSend::VERSION)
 end

--- a/samples/authentication_sample.rb
+++ b/samples/authentication_sample.rb
@@ -1,0 +1,64 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'createsend'
+
+class AuthorizationSample
+    def initialize
+        raise 'CREATESEND_API_KEY env var missing' if ENV['CREATESEND_API_KEY'].nil?
+        raise 'CREATESEND_CLIENT_ID env var missing' if ENV['CREATESEND_CLIENT_ID'].nil?
+        raise 'CREATESEND_OAUTH_CLIENT_ID env var missing' if ENV['CREATESEND_OAUTH_CLIENT_ID'].nil?
+        raise 'CREATESEND_OAUTH_CLIENT_SECRET env var missing' if ENV['CREATESEND_OAUTH_CLIENT_SECRET'].nil?
+        raise 'CREATESEND_OAUTH_REDIRECT_URL env var missing' if ENV['CREATESEND_OAUTH_REDIRECT_URL'].nil?
+        raise 'CREATESEND_OAUTH_SCOPE env var missing' if ENV['CREATESEND_OAUTH_SCOPE'].nil?
+       
+        @createsendApiKey = ENV['CREATESEND_API_KEY']
+        @oauthClientId = ENV['CREATESEND_OAUTH_CLIENT_ID']
+        @oauthClientSecret = ENV['CREATESEND_OAUTH_CLIENT_SECRET']
+        @oauthRedirectUrl = ENV['CREATESEND_OAUTH_REDIRECT_URL']
+        @oauthScope = ENV['CREATESEND_OAUTH_SCOPE']
+        )
+    end
+
+    def authentication_with_api_key
+        auth = {:api_key => @createsendApiKey}
+        @client = CreateSend::Client.new auth, @createsendClientId
+
+        @client.scheduled
+    end
+
+    def get_authorise_url
+        state = 'some state data'
+
+        @authorize_url = CreateSend::CreateSend.authorize_url(@oauthClientId, @oauthRedirectUrl, @oauthScope, state);
+    end
+
+    def exchange_token(code)
+        CreateSend::CreateSend.exchange_token(
+            client_id=@oauthClientId,
+            client_secret=@oauthClientSecret,
+            redirect_uri=@oauthRedirectUrl,
+            code=code # Get the code from the query string after hitting authorise url
+            )
+    end
+
+    def authentication_with_oauth(access_token, refresh_token)
+        auth = {:access_token => access_token, :refresh_token => refresh_token}
+        @client = CreateSend::Client.new auth, @createsendClientId
+
+        @client.scheduled
+    end
+end
+
+sample = AuthorizationSample.new
+authoriseUrl = sample.get_authorise_url
+# hit the authorise url, where you would be redirected and receive the code parameter in the query string
+access_token, expires_in, refresh_token = sample.exchange_token('code that you get once you hit authorize url')
+
+puts "Getting scheduled campaigns with api authentication: #{sample.authentication_with_api_key.to_json}\n\n"
+puts "Getting authorise url: #{authoriseUrl.to_json}\n\n"
+puts "Getting access_token: #{access_token.to_json}\n\n"
+puts "Getting scheduled campaigns with oauth authentication: #{sample.authentication_with_oauth(access_token, refresh_token).to_json}\n\n"
+
+
+        @client.scheduled
+    end
+end

--- a/samples/client_campaigns_sample.rb
+++ b/samples/client_campaigns_sample.rb
@@ -14,7 +14,7 @@ class ClientCampaignsSample
         campaigns = []
         page_number = 1
         loop do
-            page = @client.campaigns(page_number, 1000, 'desc', '', '', '')
+            page = @client.campaigns(page_number)
             page_number += 1
             campaigns.concat(page.Results)
             if page.PageNumber == page.NumberOfPages
@@ -23,6 +23,36 @@ class ClientCampaignsSample
         end
 
         campaigns
+    end
+    
+    def get_sent_campaigns_with_tag_filter
+        filtered_campaigns = []
+        page_number = 1
+        loop do
+            page = @client.campaigns(page_number, 1000, 'desc', '', '', 'tag_example, tag_example_2')
+            page_number += 1
+            filtered_campaigns.concat(page.Results)
+            if page.PageNumber == page.NumberOfPages
+                break
+            end
+        end
+
+        filtered_campaigns
+    end
+
+    def get_2021_sent_campaigns
+        2021_campaigns = []
+        page_number = 1
+        loop do
+            page = @client.campaigns(1, 1000, 'desc', '2021-01-01', '2022-01-01', '')
+            page_number += 1
+            2021_campaigns.concat(page.Results)
+            if page.PageNumber == page.NumberOfPages
+                break
+            end
+        end
+
+        2021_campaigns
     end
 
     def get_all_scheduled_campaigns
@@ -36,21 +66,13 @@ class ClientCampaignsSample
     def get_all_client_tags
         @client.tags
     end
-
-    def get_campaigns_with_tag
-        @client.campaigns(1, 1000, 'desc', '', '', 'tag_example')
-    end
-
-    def get_2021_campaigns
-        @client.campaigns(1, 1000, 'desc', '2021-01-01', '2022-01-01', '')
-    end
 end
 
 sample = ClientCampaignsSample.new
 
-puts "First page of sent campaigns: #{sample.get_all_sent_campaigns.to_json}\n\n"
+puts "All sent campaigns: #{sample.get_all_sent_campaigns.to_json}\n\n"
+puts "All sent campaigns with `tag_example` and `tag_example_2` tag: #{sample.get_sent_campaigns_with_tag_filter.to_json}\n\n"
+puts "All 2021 sent campaigns: #{sample.get_2021_sent_campaigns.to_json}\n\n"
 puts "All scheduled campaigns: #{sample.get_all_scheduled_campaigns.to_json}\n\n"
 puts "All draft campaigns: #{sample.get_all_draft_campaigns.to_json}\n\n"
 puts "All client tags: #{sample.get_all_client_tags.to_json}\n\n"
-puts "All campaigns with `tag_example` tag: #{sample.get_campaigns_with_tag.to_json}\n\n"
-puts "All 2021 campaigns: #{sample.get_2021_campaigns.to_json}\n\n"

--- a/samples/client_campaigns_sample.rb
+++ b/samples/client_campaigns_sample.rb
@@ -36,6 +36,14 @@ class ClientCampaignsSample
     def get_all_client_tags
         @client.tags
     end
+
+    def get_campaigns_with_tag
+        @client.campaigns(1, 1000, 'desc', '', '', 'tag_example')
+    end
+
+    def get_2021_campaigns
+        @client.campaigns(1, 1000, 'desc', '2021-01-01', '2022-01-01', '')
+    end
 end
 
 sample = ClientCampaignsSample.new
@@ -44,3 +52,5 @@ puts "First page of sent campaigns: #{sample.get_all_sent_campaigns.to_json}\n\n
 puts "All scheduled campaigns: #{sample.get_all_scheduled_campaigns.to_json}\n\n"
 puts "All draft campaigns: #{sample.get_all_draft_campaigns.to_json}\n\n"
 puts "All client tags: #{sample.get_all_client_tags.to_json}\n\n"
+puts "All campaigns with `tag_example` tag: #{sample.get_campaigns_with_tag.to_json}\n\n"
+puts "All 2021 campaigns: #{sample.get_2021_campaigns.to_json}\n\n"

--- a/samples/client_campaigns_sample.rb
+++ b/samples/client_campaigns_sample.rb
@@ -1,0 +1,46 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'createsend'
+
+class ClientCampaignsSample
+    def initialize
+        raise 'CREATESEND_API_KEY env var missing' if ENV['CREATESEND_API_KEY'].nil?
+        raise 'CREATESEND_CLIENT_ID env var missing' if ENV['CREATESEND_CLIENT_ID'].nil?
+
+        auth = {:api_key => ENV['CREATESEND_API_KEY']}
+        @client = CreateSend::Client.new auth, ENV['CREATESEND_CLIENT_ID']
+    end
+
+    def get_all_sent_campaigns
+        campaigns = []
+        page_number = 1
+        loop do
+            page = @client.campaigns(page_number, 1000, 'desc', '', '', '')
+            page_number += 1
+            campaigns.concat(page.Results)
+            if page.PageNumber == page.NumberOfPages
+                break
+            end
+        end
+
+        campaigns
+    end
+
+    def get_all_scheduled_campaigns
+        @client.scheduled
+    end
+
+    def get_all_draft_campaigns
+        @client.drafts
+    end
+
+    def get_all_client_tags
+        @client.tags
+    end
+end
+
+sample = ClientCampaignsSample.new
+
+puts "First page of sent campaigns: #{sample.get_all_sent_campaigns.to_json}\n\n"
+puts "All scheduled campaigns: #{sample.get_all_scheduled_campaigns.to_json}\n\n"
+puts "All draft campaigns: #{sample.get_all_draft_campaigns.to_json}\n\n"
+puts "All client tags: #{sample.get_all_client_tags.to_json}\n\n"

--- a/samples/clients_sample.rb
+++ b/samples/clients_sample.rb
@@ -1,12 +1,13 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'createsend'
 
-class ClientCampaignsSample
+class ClientsSample
     def initialize
-        raise 'CREATESEND_API_KEY env var missing' if ENV['CREATESEND_API_KEY'].nil?
+        raise 'CREATESEND_ACCESS_TOKEN env var missing' if ENV['CREATESEND_ACCESS_TOKEN'].nil?
+        raise 'CREATESEND_REFRESH_TOKEN env var missing' if ENV['CREATESEND_REFRESH_TOKEN'].nil?
         raise 'CREATESEND_CLIENT_ID env var missing' if ENV['CREATESEND_CLIENT_ID'].nil?
 
-        auth = {:api_key => ENV['CREATESEND_API_KEY']}
+        auth = auth = {:access_token => ENV['CREATESEND_ACCESS_TOKEN'], :refresh_token => ENV['CREATESEND_REFRESH_TOKEN']}
         @client = CreateSend::Client.new auth, ENV['CREATESEND_CLIENT_ID']
     end
 
@@ -68,7 +69,7 @@ class ClientCampaignsSample
     end
 end
 
-sample = ClientCampaignsSample.new
+sample = ClientsSample.new
 
 puts "All sent campaigns: #{sample.get_all_sent_campaigns.to_json}\n\n"
 puts "All sent campaigns with `tag_example` and `tag_example_2` tag: #{sample.get_sent_campaigns_with_tag_filter.to_json}\n\n"

--- a/samples/journey_sample.rb
+++ b/samples/journey_sample.rb
@@ -5,12 +5,13 @@ class JourneySample
   @date = "2019-01-01 00:00"
 
   def initialize
-    raise 'CREATESEND_API_KEY env var missing' if ENV['CREATESEND_API_KEY'].nil?
+    raise 'CREATESEND_ACCESS_TOKEN env var missing' if ENV['CREATESEND_ACCESS_TOKEN'].nil?
+    raise 'CREATESEND_REFRESH_TOKEN env var missing' if ENV['CREATESEND_REFRESH_TOKEN'].nil?
     raise 'CREATESEND_CLIENT_ID env var missing' if ENV['CREATESEND_CLIENT_ID'].nil?
     raise 'CREATESEND_JOURNEY_ID env var missing' if ENV['CREATESEND_JOURNEY_ID'].nil?
     raise 'CREATESEND_EMAIL_ID env var missing' if ENV['CREATESEND_EMAIL_ID'].nil?
 
-    auth = {:api_key => ENV['CREATESEND_API_KEY']}
+    auth = {:access_token => ENV['CREATESEND_ACCESS_TOKEN'], :refresh_token => ENV['CREATESEND_REFRESH_TOKEN']}
     @client = CreateSend::Client.new auth, ENV['CREATESEND_CLIENT_ID']
     @journey = CreateSend::Journey.new auth, ENV['CREATESEND_JOURNEY_ID']
   end

--- a/samples/lists_sample.rb
+++ b/samples/lists_sample.rb
@@ -1,0 +1,41 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'createsend'
+
+class ListsSample
+    def initialize
+        raise 'CREATESEND_ACCESS_TOKEN env var missing' if ENV['CREATESEND_ACCESS_TOKEN'].nil?
+        raise 'CREATESEND_REFRESH_TOKEN env var missing' if ENV['CREATESEND_REFRESH_TOKEN'].nil?
+        raise 'CREATESEND_LIST_ID env var missing' if ENV['CREATESEND_LIST_ID'].nil?
+
+        auth = {:access_token => ENV['CREATESEND_ACCESS_TOKEN'], :refresh_token => ENV['CREATESEND_REFRESH_TOKEN']}
+        @list = CreateSend::List.new auth, ENV['CREATESEND_LIST_ID']
+    end
+
+    def get_active_subscribers
+        @list.active
+    end
+
+    def get_bounced_subscribers
+        @list.bounced
+    end
+
+    def get_unsubscribed_subscribers
+        @list.unsubscribed
+    end
+
+    def get_unconfirmed_subscribers
+        @list.unconfirmed
+    end
+
+    def get_deleted_subscribers
+        @list.deleted
+    end
+end
+
+sample = ListsSample.new
+
+puts "All active subscribers: #{sample.get_active_subscribers.to_json}\n\n"
+puts "All bounced subscribers: #{sample.get_bounced_subscribers.to_json}\n\n"
+puts "All unsubscribed subscribers: #{sample.get_unsubscribed_subscribers.to_json}\n\n"
+puts "All unconfirmed subscribers: #{sample.get_unconfirmed_subscribers.to_json}\n\n"
+puts "All deleted subscribers: #{sample.get_deleted_subscribers.to_json}\n\n"

--- a/samples/segments_sample.rb
+++ b/samples/segments_sample.rb
@@ -1,0 +1,21 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'createsend'
+
+class SegmentsSample
+    def initialize
+        raise 'CREATESEND_ACCESS_TOKEN env var missing' if ENV['CREATESEND_ACCESS_TOKEN'].nil?
+        raise 'CREATESEND_REFRESH_TOKEN env var missing' if ENV['CREATESEND_REFRESH_TOKEN'].nil?
+        raise 'CREATESEND_SEGMENT_ID env var missing' if ENV['CREATESEND_SEGMENT_ID'].nil?
+
+        auth = {:access_token => ENV['CREATESEND_ACCESS_TOKEN'], :refresh_token => ENV['CREATESEND_REFRESH_TOKEN']}
+        @segment = CreateSend::Segment.new auth, ENV['CREATESEND_SEGMENT_ID']
+    end
+
+    def get_active_subscribers
+        @segment.subscribers
+    end
+end
+
+sample = SegmentsSample.new
+
+puts "All active subscribers: #{sample.get_active_subscribers.to_json}\n\n"

--- a/samples/subscribes_sample.rb
+++ b/samples/subscribes_sample.rb
@@ -1,0 +1,22 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'createsend'
+
+class SubscribersSample
+    def initialize
+        raise 'CREATESEND_ACCESS_TOKEN env var missing' if ENV['CREATESEND_ACCESS_TOKEN'].nil?
+        raise 'CREATESEND_REFRESH_TOKEN env var missing' if ENV['CREATESEND_REFRESH_TOKEN'].nil?
+        raise 'CREATESEND_LIST_ID env var missing' if ENV['CREATESEND_LIST_ID'].nil?
+        raise 'CREATESEND_EMAIL_ADDRESS env var missing' if ENV['CREATESEND_EMAIL_ADDRESS'].nil?
+
+        auth = {:access_token => ENV['CREATESEND_ACCESS_TOKEN'], :refresh_token => ENV['CREATESEND_REFRESH_TOKEN']}
+        @subscriber = CreateSend::Subscriber.get auth, ENV['CREATESEND_LIST_ID'], ENV['CREATESEND_EMAIL_ADDRESS']
+    end
+
+    def get_subscriber
+        @subscriber
+    end
+end
+
+sample = SubscribersSample.new
+
+puts "detailed subscribers: #{sample.get_subscriber.to_json}\n\n"

--- a/test/campaign_test.rb
+++ b/test/campaign_test.rb
@@ -137,6 +137,7 @@ class CampaignTest < Test::Unit::TestCase
     should "get the summary for a campaign" do
       stub_get(@auth, "campaigns/#{@campaign.campaign_id}/summary.json", "campaign_summary.json")
       summary = @campaign.summary
+      summary.Name.should == "Campaign Name"
       summary.Recipients.should == 5
       summary.TotalOpened.should == 10
       summary.Clicks.should == 0

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -26,9 +26,17 @@ class ClientTest < Test::Unit::TestCase
     end
 
     should "get all campaigns" do
-      stub_get(@auth, "clients/#{@client.client_id}/campaigns.json", "campaigns.json")
+      stub_get(@auth, "clients/#{@client.client_id}/campaigns.json?page=1&pagesize=1000&orderdirection=desc&sentfromdate=&senttodate=&tags=", "campaigns.json")
       campaigns = @client.campaigns
       campaigns.Results.size.should == 2
+      campaigns.ResultsOrderedBy == 'sentdate'
+      campaigns.OrderDirection = 'desc'
+      campaigns.PageNumber == 1
+      campaigns.PageSize == 1000
+      campaigns.RecordsOnThisPage == 2
+      campaigns.TotalNumberOfRecords == 2
+      campaigns.NumberOfPages == 1
+
       campaign = campaigns.Results.first
       campaign.CampaignID.should == 'fc0ce7105baeaf97f47c99be31d02a91'
       campaign.WebVersionURL.should == 'http://createsend.com/t/r-765E86829575EE2C'

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -85,7 +85,7 @@ class ClientTest < Test::Unit::TestCase
       tags.size.should == 2
       tag = tags.first
       tag.Name.should == 'Tag One'
-      tag.NumberOfCampaigns.should == '62'
+      tag.NumberOfCampaigns.should == '120'
     end
 
     should "get all lists" do

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -28,49 +28,64 @@ class ClientTest < Test::Unit::TestCase
     should "get all campaigns" do
       stub_get(@auth, "clients/#{@client.client_id}/campaigns.json", "campaigns.json")
       campaigns = @client.campaigns
-      campaigns.size.should == 2
-      campaigns.first.CampaignID.should == 'fc0ce7105baeaf97f47c99be31d02a91'
-      campaigns.first.WebVersionURL.should == 'http://createsend.com/t/r-765E86829575EE2C'
-      campaigns.first.WebVersionTextURL.should == 'http://createsend.com/t/r-765E86829575EE2C/t'
-      campaigns.first.Subject.should == 'Campaign One'
-      campaigns.first.Name.should == 'Campaign One'
-      campaigns.first.SentDate.should == '2010-10-12 12:58:00'
-      campaigns.first.TotalRecipients.should == 2245
-      campaigns.first.FromName.should == 'My Name'
-      campaigns.first.FromEmail.should == 'myemail@example.com'
-      campaigns.first.ReplyTo.should == 'myemail@example.com'
+      campaigns.Results.size.should == 2
+      campaign = campaigns.Results.first
+      campaign.CampaignID.should == 'fc0ce7105baeaf97f47c99be31d02a91'
+      campaign.WebVersionURL.should == 'http://createsend.com/t/r-765E86829575EE2C'
+      campaign.WebVersionTextURL.should == 'http://createsend.com/t/r-765E86829575EE2C/t'
+      campaign.Subject.should == 'Campaign One'
+      campaign.Name.should == 'Campaign One'
+      campaign.SentDate.should == '2010-10-12 12:58:00'
+      campaign.TotalRecipients.should == 2245
+      campaign.FromName.should == 'My Name'
+      campaign.FromEmail.should == 'myemail@example.com'
+      campaign.ReplyTo.should == 'myemail@example.com'
+      campaign.Tags.should == []
     end
 
     should "get scheduled campaigns" do
       stub_get(@auth, "clients/#{@client.client_id}/scheduled.json", "scheduled_campaigns.json")
       campaigns = @client.scheduled
       campaigns.size.should == 2
-      campaigns.first.DateScheduled.should == "2011-05-25 10:40:00"
-      campaigns.first.ScheduledTimeZone.should == "(GMT+10:00) Canberra, Melbourne, Sydney"
-      campaigns.first.CampaignID.should == "827dbbd2161ea9989fa11ad562c66937"
-      campaigns.first.Name.should == "Magic Issue One"
-      campaigns.first.Subject.should == "Magic Issue One"
-      campaigns.first.DateCreated.should == "2011-05-24 10:37:00"
-      campaigns.first.PreviewURL.should == "http://createsend.com/t/r-DD543521A87C9B8B"
-      campaigns.first.PreviewTextURL.should == "http://createsend.com/t/r-DD543521A87C9B8B/t"
-      campaigns.first.FromName.should == 'My Name'
-      campaigns.first.FromEmail.should == 'myemail@example.com'
-      campaigns.first.ReplyTo.should == 'myemail@example.com'
+      campaign = campaigns.first
+      campaign.DateScheduled.should == "2011-05-25 10:40:00"
+      campaign.ScheduledTimeZone.should == "(GMT+10:00) Canberra, Melbourne, Sydney"
+      campaign.CampaignID.should == "827dbbd2161ea9989fa11ad562c66937"
+      campaign.Name.should == "Magic Issue One"
+      campaign.Subject.should == "Magic Issue One"
+      campaign.DateCreated.should == "2011-05-24 10:37:00"
+      campaign.PreviewURL.should == "http://createsend.com/t/r-DD543521A87C9B8B"
+      campaign.PreviewTextURL.should == "http://createsend.com/t/r-DD543521A87C9B8B/t"
+      campaign.FromName.should == 'My Name'
+      campaign.FromEmail.should == 'myemail@example.com'
+      campaign.ReplyTo.should == 'myemail@example.com'
+      campaign.Tags.should == ['tagexample']
     end
 
     should "get all drafts" do
       stub_get(@auth, "clients/#{@client.client_id}/drafts.json", "drafts.json")
       drafts = @client.drafts
       drafts.size.should == 2
-      drafts.first.CampaignID.should == '7c7424792065d92627139208c8c01db1'
-      drafts.first.Name.should == 'Draft One'
-      drafts.first.Subject.should == 'Draft One'
-      drafts.first.DateCreated.should == '2010-08-19 16:08:00'
-      drafts.first.PreviewURL.should == 'http://createsend.com/t/r-E97A7BB2E6983DA1'
-      drafts.first.PreviewTextURL.should == 'http://createsend.com/t/r-E97A7BB2E6983DA1/t'
-      drafts.first.FromName.should == 'My Name'
-      drafts.first.FromEmail.should == 'myemail@example.com'
-      drafts.first.ReplyTo.should == 'myemail@example.com'
+      draft = drafts.first
+      draft.CampaignID.should == '7c7424792065d92627139208c8c01db1'
+      draft.Name.should == 'Draft One'
+      draft.Subject.should == 'Draft One'
+      draft.DateCreated.should == '2010-08-19 16:08:00'
+      draft.PreviewURL.should == 'http://createsend.com/t/r-E97A7BB2E6983DA1'
+      draft.PreviewTextURL.should == 'http://createsend.com/t/r-E97A7BB2E6983DA1/t'
+      draft.FromName.should == 'My Name'
+      draft.FromEmail.should == 'myemail@example.com'
+      draft.ReplyTo.should == 'myemail@example.com'
+      draft.Tags.should == ['tagexample']
+    end
+
+    should "get all client tags" do
+      stub_get(@auth, "clients/#{@client.client_id}/tags.json", "tags.json")
+      tags = @client.tags
+      tags.size.should == 2
+      tag = tags.first
+      tag.Name.should == 'Tag One'
+      tag.NumberOfCampaigns.should == '62'
     end
 
     should "get all lists" do

--- a/test/fixtures/active_subscribers.json
+++ b/test/fixtures/active_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "subs+7t8787Y@example.com",
       "Name": "Person One",
       "Date": "2010-10-25 10:28:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Active",
       "CustomFields": [
         {
@@ -33,6 +34,7 @@
       "EmailAddress": "subs+7878787y8ggg@example.com",
       "Name": "Person Two",
       "Date": "2010-10-25 12:17:00",
+      "ListJoinedDate": "2010-10-25 12:17:00",
       "State": "Active",
       "CustomFields": [
         {
@@ -46,6 +48,7 @@
       "EmailAddress": "subs+7890909i0ggg@example.com",
       "Name": "Person Three",
       "Date": "2010-10-25 12:52:00",
+      "ListJoinedDate": "2010-10-25 12:52:00",
       "State": "Active",
       "CustomFields": [
         {
@@ -59,6 +62,7 @@
       "EmailAddress": "subs@example.com",
       "Name": "Person Four",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -67,6 +71,7 @@
       "EmailAddress": "joey@example.com",
       "Name": "Person Five",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"

--- a/test/fixtures/bounced_subscribers.json
+++ b/test/fixtures/bounced_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "bouncedsubscriber@example.com",
       "Name": "Bounced One",
       "Date": "2010-10-25 13:11:00",
+      "ListJoinedDate": "2010-10-25 13:11:00",
       "State": "Bounced",
       "CustomFields": [],
       "ReadsEmailWith": ""

--- a/test/fixtures/campaign_summary.json
+++ b/test/fixtures/campaign_summary.json
@@ -11,5 +11,6 @@
   "WebVersionURL": "http://createsend.com/t/r-3A433FC72FFE3B8B",
   "WebVersionTextURL": "http://createsend.com/t/r-3A433FC72FFE3B8B/t",
   "WorldviewURL": "http://client.createsend.com/reports/wv/r/3A433FC72FFE3B8B",
-  "SpamComplaints": 23
+  "SpamComplaints": 23,
+  "Name": "Campaign Name"
 }

--- a/test/fixtures/campaigns.json
+++ b/test/fixtures/campaigns.json
@@ -1,26 +1,37 @@
-[
-  {
-    "WebVersionURL": "http://createsend.com/t/r-765E86829575EE2C",
-    "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
-    "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
-    "Subject": "Campaign One",
-    "Name": "Campaign One",
-    "FromName": "My Name",
-    "FromEmail": "myemail@example.com",
-    "ReplyTo": "myemail@example.com",
-    "SentDate": "2010-10-12 12:58:00",
-    "TotalRecipients": 2245
-  },
-  {
-    "WebVersionURL": "http://createsend.com/t/r-DD543566A87C9B8B",
-    "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
-    "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
-    "Subject": "Campaign Two",
-    "Name": "Campaign Two",
-    "FromName": "My Name",
-    "FromEmail": "myemail@example.com",
-    "ReplyTo": "myemail@example.com",
-    "SentDate": "2010-10-06 16:20:00",
-    "TotalRecipients": 11222
-  }
-]
+{
+  "Results": [
+    {
+      "WebVersionURL": "http://createsend.com/t/r-765E86829575EE2C",
+      "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
+      "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
+      "Subject": "Campaign One",
+      "Name": "Campaign One",
+      "FromName": "My Name",
+      "FromEmail": "myemail@example.com",
+      "ReplyTo": "myemail@example.com",
+      "SentDate": "2010-10-12 12:58:00",
+      "TotalRecipients": 2245,
+      "Tags": []
+    },
+    {
+      "WebVersionURL": "http://createsend.com/t/r-DD543566A87C9B8B",
+      "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
+      "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
+      "Subject": "Campaign Two",
+      "Name": "Campaign Two",
+      "FromName": "My Name",
+      "FromEmail": "myemail@example.com",
+      "ReplyTo": "myemail@example.com",
+      "SentDate": "2010-10-06 16:20:00",
+      "TotalRecipients": 11222,
+      "Tags": ["tagexample"]
+    }
+  ],
+  "ResultsOrderedBy": "sentdate",
+  "OrderDirection": "desc",
+  "PageNumber": 1,
+  "PageSize": 1000,
+  "RecordsOnThisPage": 2,
+  "TotalNumberOfRecords": 2,
+  "NumberOfPages": 1
+}

--- a/test/fixtures/deleted_subscribers.json
+++ b/test/fixtures/deleted_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "subscriber@example.com",
       "Name": "Deleted One",
       "Date": "2010-10-25 13:11:00",
+      "ListJoinedDate": "2010-10-25 13:11:00",
       "State": "Deleted",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"
@@ -12,6 +13,7 @@
       "EmailAddress": "subscriberone@example.com",
       "Name": "Subscriber",
       "Date": "2010-10-25 13:04:00",
+      "ListJoinedDate": "2010-10-25 13:04:00",
       "State": "Deleted",
       "CustomFields": [
         {
@@ -25,6 +27,7 @@
       "EmailAddress": "example+1@example.com",
       "Name": "Example One",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Deleted",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -33,6 +36,7 @@
       "EmailAddress": "example+2@example.com",
       "Name": "Example Two",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Deleted",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -41,6 +45,7 @@
       "EmailAddress": "example+3@example.com",
       "Name": "Example Three",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Deleted",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"

--- a/test/fixtures/drafts.json
+++ b/test/fixtures/drafts.json
@@ -8,7 +8,8 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
     "PreviewURL": "http://createsend.com/t/r-E97A7BB2E6983DA1",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "Tags": ["tagexample"]
   },
   {
     "CampaignID": "2e928e982065d92627139208c8c01db1",
@@ -19,6 +20,7 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
     "PreviewURL": "http://createsend.com/t/r-E97A7BB2E6983DA1",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "Tags": []
   }
 ]

--- a/test/fixtures/scheduled_campaigns.json
+++ b/test/fixtures/scheduled_campaigns.json
@@ -10,7 +10,8 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:37:00",
     "PreviewURL": "http://createsend.com/t/r-DD543521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t"
+    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t",
+    "Tags": ["tagexample"]
   },
   {
     "DateScheduled": "2011-05-29 11:20:00",
@@ -23,6 +24,7 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:39:00",
     "PreviewURL": "http://createsend.com/t/r-DD913521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t"
+    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t",
+    "Tags": []
   }
 ]

--- a/test/fixtures/segment_subscribers.json
+++ b/test/fixtures/segment_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "personone@example.com",
       "Name": "Person One",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": []
     },
@@ -11,6 +12,7 @@
       "EmailAddress": "persontwo@example.com",
       "Name": "Person Two",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": []
     }

--- a/test/fixtures/subscriber_details.json
+++ b/test/fixtures/subscriber_details.json
@@ -2,6 +2,7 @@
   "EmailAddress": "subscriber@example.com",
   "Name": "Subscriber One",
   "Date": "2010-10-25 10:28:00",
+  "ListJoinedDate": "2010-10-25 10:28:00",
   "State": "Active",
   "CustomFields": [
     {

--- a/test/fixtures/subscriber_details_with_track_pref.json
+++ b/test/fixtures/subscriber_details_with_track_pref.json
@@ -2,6 +2,7 @@
   "EmailAddress": "subscriber@example.com",
   "Name": "Subscriber One",
   "Date": "2010-10-25 10:28:00",
+  "ListJoinedDate": "2010-10-25 10:28:00",
   "State": "Active",
   "CustomFields": [
     {

--- a/test/fixtures/tags.json
+++ b/test/fixtures/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Name": "Tag One", 
+    "NumberOfCampaigns": "120"
+  },
+  {        
+    "Name": "Tag Two",
+    "NumberOfCampaigns": "62"
+  }
+]

--- a/test/fixtures/unconfirmed_subscribers.json
+++ b/test/fixtures/unconfirmed_subscribers.json
@@ -4,6 +4,7 @@
             "EmailAddress": "subs+7t8787Y@example.com",
             "Name": "Unconfirmed One",
             "Date": "2010-10-25 10:28:00",
+            "ListJoinedDate": "2010-10-25 10:28:00",
             "State": "Unconfirmed",
             "CustomFields": [
                 {
@@ -18,6 +19,7 @@
             "EmailAddress": "subs+7878787y8ggg@example.com",
             "Name": "Unconfirmed Two",
             "Date": "2010-10-25 12:17:00",
+            "ListJoinedDate": "2010-10-25 12:17:00",
             "State": "Unconfirmed",
             "CustomFields": [
                 {

--- a/test/fixtures/unsubscribed_subscribers.json
+++ b/test/fixtures/unsubscribed_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "subscriber@example.com",
       "Name": "Unsub One",
       "Date": "2010-10-25 13:11:00",
+      "ListJoinedDate": "2010-10-25 13:11:00",
       "State": "Unsubscribed",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"
@@ -12,6 +13,7 @@
       "EmailAddress": "subscriberone@example.com",
       "Name": "Subscriber",
       "Date": "2010-10-25 13:04:00",
+      "ListJoinedDate": "2010-10-25 13:04:00",
       "State": "Unsubscribed",
       "CustomFields": [
         {
@@ -25,6 +27,7 @@
       "EmailAddress": "example+1@example.com",
       "Name": "Example One",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Unsubscribed",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -33,6 +36,7 @@
       "EmailAddress": "example+2@example.com",
       "Name": "Example Two",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Unsubscribed",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -41,6 +45,7 @@
       "EmailAddress": "example+3@example.com",
       "Name": "Example Three",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Unsubscribed",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,7 +11,7 @@ require 'test/unit'
 require 'pathname'
 
 require 'shoulda/context'
-require 'matchy'
+#require 'matchy'
 require 'fakeweb'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
@@ -30,7 +30,7 @@ def createsend_url(auth, url)
   if not url =~ /^http/
     auth_section = ''
     auth_section = "#{auth[:api_key]}:x@" if auth and auth.has_key? :api_key
-    result = "https://#{auth_section}api.createsend.com/api/v3.2/#{url}"
+    result = "https://#{auth_section}api.createsend.com/api/v3.3/#{url}"
   else
     result = url
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,7 @@ require 'test/unit'
 require 'pathname'
 
 require 'shoulda/context'
+require 'matchy'
 require 'fakeweb'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,7 +11,6 @@ require 'test/unit'
 require 'pathname'
 
 require 'shoulda/context'
-#require 'matchy'
 require 'fakeweb'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -143,6 +143,7 @@ class ListTest < Test::Unit::TestCase
       res.Results.first.EmailAddress.should == "subs+7t8787Y@example.com"
       res.Results.first.Name.should =="Person One"
       res.Results.first.Date.should == "2010-10-25 10:28:00"
+      res.Results.first.ListJoinedDate.should == "2010-10-25 10:28:00"
       res.Results.first.State.should == "Active"
       res.Results.first.CustomFields.size.should == 5
       res.Results.first.CustomFields[0].Key.should == "website"
@@ -169,6 +170,8 @@ class ListTest < Test::Unit::TestCase
       res.Results.size.should == 2
       res.Results.first.EmailAddress.should == "subs+7t8787Y@example.com"
       res.Results.first.Name.should =="Unconfirmed One"
+      res.Results.first.Date.should =="2010-10-25 10:28:00"
+      res.Results.first.ListJoinedDate.should =="2010-10-25 10:28:00"
       res.Results.first.State.should == "Unconfirmed"
       res.Results.first.ConsentToTrack.should == "Yes"
     end
@@ -189,6 +192,7 @@ class ListTest < Test::Unit::TestCase
       res.Results.first.EmailAddress.should == "subscriber@example.com"
       res.Results.first.Name.should == "Unsub One"
       res.Results.first.Date.should == "2010-10-25 13:11:00"
+      res.Results.first.ListJoinedDate.should == "2010-10-25 13:11:00"
       res.Results.first.State.should == "Unsubscribed"
       res.Results.first.CustomFields.size.should == 0
       res.Results.first.ReadsEmailWith.should == "Gmail"
@@ -210,6 +214,7 @@ class ListTest < Test::Unit::TestCase
       res.Results.first.EmailAddress.should == "subscriber@example.com"
       res.Results.first.Name.should == "Deleted One"
       res.Results.first.Date.should == "2010-10-25 13:11:00"
+      res.Results.first.ListJoinedDate.should == "2010-10-25 13:11:00"
       res.Results.first.State.should == "Deleted"
       res.Results.first.CustomFields.size.should == 0
       res.Results.first.ReadsEmailWith.should == "Gmail"
@@ -231,6 +236,7 @@ class ListTest < Test::Unit::TestCase
       res.Results.first.EmailAddress.should == "bouncedsubscriber@example.com"
       res.Results.first.Name.should == "Bounced One"
       res.Results.first.Date.should == "2010-10-25 13:11:00"
+      res.Results.first.ListJoinedDate.should == "2010-10-25 13:11:00"
       res.Results.first.State.should == "Bounced"
       res.Results.first.CustomFields.size.should == 0
       res.Results.first.ReadsEmailWith.should == ""

--- a/test/segment_test.rb
+++ b/test/segment_test.rb
@@ -42,6 +42,7 @@ class SegmentTest < Test::Unit::TestCase
       res.Results.first.EmailAddress.should == "personone@example.com"
       res.Results.first.Name.should == "Person One"
       res.Results.first.Date.should == "2010-10-27 13:13:00"
+      res.Results.first.ListJoinedDate.should == "2010-10-27 13:13:00"
       res.Results.first.State.should == "Active"
       res.Results.first.CustomFields.should == []
     end

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -14,6 +14,7 @@ class SubscriberTest < Test::Unit::TestCase
       subscriber.EmailAddress.should == email
       subscriber.Name.should == "Subscriber One"
       subscriber.Date.should == "2010-10-25 10:28:00"
+      subscriber.ListJoinedDate.should == "2010-10-25 10:28:00"
       subscriber.State.should == "Active"
       subscriber.CustomFields.size.should == 3
       subscriber.CustomFields.first.Key.should == 'website'


### PR DESCRIPTION
Upgrades to Createsend API v3.3 which includes new breaking changes

- New client tags() returns the list of tags
- Client draftCampaigns() now return Tags
- Client scheduledCampaigns() now returns Tags
- Revamped client sentCampaigns() includes these improvements:
  - The method returns a PagedResult of SentCampaign.
  - Entries can be fetched using the Page parameter.
  - Up to 1000 entries are returned per method call. A different amount can be returned by setting the PageSize value.
  - Campaigns can be sorted by their Sent Date using OrderDirection
  - Campaigns can be filtered by Sent Date using sentFromDate and sentToDate in YYYY-MM-DD format
  - Campaigns can be filtered by their tags.
- Campaign summary() now returns Name