### PR TITLE
Support for MobileNumber and ConsentToSendSms in Subscribers API

### DIFF
--- a/lib/createsend/subscriber.rb
+++ b/lib/createsend/subscriber.rb
@@ -22,8 +22,8 @@ module CreateSend
     end
 
     # Adds a subscriber to a subscriber list.
-    def self.add(auth, list_id, email_address, name, mobile_number, custom_fields, resubscribe, 
-      consent_to_track, consent_to_send_sms, restart_subscription_based_autoresponders=false)
+    def self.add(auth, list_id, email_address, name, custom_fields, resubscribe, 
+      consent_to_track, restart_subscription_based_autoresponders=false, mobile_number=nil, consent_to_send_sms='No')
       options = { :body => {
         :EmailAddress => email_address,
         :Name => name,
@@ -71,8 +71,8 @@ module CreateSend
 
     # Updates any aspect of a subscriber, including email address, name, and
     # custom field data if supplied.
-    def update(new_email_address, name, mobile_number, custom_fields, resubscribe, 
-      consent_to_track, consent_to_send_sms, restart_subscription_based_autoresponders=false)
+    def update(new_email_address, name, custom_fields, resubscribe, 
+      consent_to_track, restart_subscription_based_autoresponders=false, mobile_number=nil, consent_to_send_sms='No')
       options = {
         :query => { :email => @email_address },
         :body => {

--- a/lib/createsend/subscriber.rb
+++ b/lib/createsend/subscriber.rb
@@ -23,7 +23,7 @@ module CreateSend
 
     # Adds a subscriber to a subscriber list.
     def self.add(auth, list_id, email_address, name, custom_fields, resubscribe, 
-      consent_to_track, restart_subscription_based_autoresponders=false)
+      consent_to_track, consent_to_send_sms, restart_subscription_based_autoresponders=false)
       options = { :body => {
         :EmailAddress => email_address,
         :Name => name,
@@ -31,7 +31,8 @@ module CreateSend
         :Resubscribe => resubscribe,
         :RestartSubscriptionBasedAutoresponders => 
           restart_subscription_based_autoresponders,
-        :ConsentToTrack => consent_to_track }.to_json }
+        :ConsentToTrack => consent_to_track,
+        :ConsentToSendSms => consent_to_send_sms }.to_json }
       cs = CreateSend.new auth
       response = cs.post "/subscribers/#{list_id}.json", options
       response.parsed_response
@@ -70,7 +71,7 @@ module CreateSend
     # Updates any aspect of a subscriber, including email address, name, and
     # custom field data if supplied.
     def update(new_email_address, name, custom_fields, resubscribe, 
-      consent_to_track, restart_subscription_based_autoresponders=false)
+      consent_to_track, consent_to_send_sms, restart_subscription_based_autoresponders=false)
       options = {
         :query => { :email => @email_address },
         :body => {
@@ -80,7 +81,8 @@ module CreateSend
           :Resubscribe => resubscribe,
           :RestartSubscriptionBasedAutoresponders => 
             restart_subscription_based_autoresponders,
-          :ConsentToTrack => consent_to_track }.to_json }
+          :ConsentToTrack => consent_to_track,
+          :ConsentToSendSms => consent_to_send_sms }.to_json }
       put "/subscribers/#{@list_id}.json", options
       # Update @email_address, so this object can continue to be used reliably
       @email_address = new_email_address

--- a/lib/createsend/subscriber.rb
+++ b/lib/createsend/subscriber.rb
@@ -22,11 +22,12 @@ module CreateSend
     end
 
     # Adds a subscriber to a subscriber list.
-    def self.add(auth, list_id, email_address, name, custom_fields, resubscribe, 
+    def self.add(auth, list_id, email_address, name, mobile_number, custom_fields, resubscribe, 
       consent_to_track, consent_to_send_sms, restart_subscription_based_autoresponders=false)
       options = { :body => {
         :EmailAddress => email_address,
         :Name => name,
+        :MobileNumber => mobile_number,
         :CustomFields => custom_fields,
         :Resubscribe => resubscribe,
         :RestartSubscriptionBasedAutoresponders => 
@@ -70,13 +71,14 @@ module CreateSend
 
     # Updates any aspect of a subscriber, including email address, name, and
     # custom field data if supplied.
-    def update(new_email_address, name, custom_fields, resubscribe, 
+    def update(new_email_address, name, mobile_number, custom_fields, resubscribe, 
       consent_to_track, consent_to_send_sms, restart_subscription_based_autoresponders=false)
       options = {
         :query => { :email => @email_address },
         :body => {
           :EmailAddress => new_email_address,
           :Name => name,
+          :MobileNumber => mobile_number,
           :CustomFields => custom_fields,
           :Resubscribe => resubscribe,
           :RestartSubscriptionBasedAutoresponders => 

--- a/test/fixtures/subscriber_details.json
+++ b/test/fixtures/subscriber_details.json
@@ -1,6 +1,7 @@
 {
   "EmailAddress": "subscriber@example.com",
   "Name": "Subscriber One",
+  "MobileNumber": "0123456000",
   "Date": "2010-10-25 10:28:00",
   "ListJoinedDate": "2010-10-25 10:28:00",
   "State": "Active",

--- a/test/fixtures/subscriber_details_with_track_and_sms_pref.json
+++ b/test/fixtures/subscriber_details_with_track_and_sms_pref.json
@@ -19,5 +19,6 @@
     }
   ],
   "ReadsEmailWith": "Gmail",
-  "ConsentToTrack": "Yes"
+  "ConsentToTrack": "Yes",
+  "ConsentToSendSms": "No"
 }

--- a/test/fixtures/subscriber_details_with_track_and_sms_pref.json
+++ b/test/fixtures/subscriber_details_with_track_and_sms_pref.json
@@ -1,6 +1,7 @@
 {
   "EmailAddress": "subscriber@example.com",
   "Name": "Subscriber One",
+  "MobileNumber": "123456000",
   "Date": "2010-10-25 10:28:00",
   "ListJoinedDate": "2010-10-25 10:28:00",
   "State": "Active",

--- a/test/fixtures/unconfirmed_subscribers.json
+++ b/test/fixtures/unconfirmed_subscribers.json
@@ -13,7 +13,8 @@
                 }
             ],
             "ReadsEmailWith": "",
-            "ConsentToTrack": "Yes"
+            "ConsentToTrack": "Yes",
+            "ConsentToSendSms": "No"
         },
         {
             "EmailAddress": "subs+7878787y8ggg@example.com",
@@ -28,7 +29,8 @@
                 }
             ],
             "ReadsEmailWith": "",
-            "ConsentToTrack": "No"
+            "ConsentToTrack": "No",
+            "ConsentToSendSms": "No"
         }
     ],
     "ResultsOrderedBy": "email",

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -174,6 +174,7 @@ class ListTest < Test::Unit::TestCase
       res.Results.first.ListJoinedDate.should =="2010-10-25 10:28:00"
       res.Results.first.State.should == "Unconfirmed"
       res.Results.first.ConsentToTrack.should == "Yes"
+      res.Results.first.ConsentToSendSms.should == "No"
     end
 
     should "get the unsubscribed subscribers for a list" do

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -13,6 +13,7 @@ class SubscriberTest < Test::Unit::TestCase
       subscriber = CreateSend::Subscriber.get @auth, @list_id, email
       subscriber.EmailAddress.should == email
       subscriber.Name.should == "Subscriber One"
+      subscriber.MobileNumber.should == "0123456000"
       subscriber.Date.should == "2010-10-25 10:28:00"
       subscriber.ListJoinedDate.should == "2010-10-25 10:28:00"
       subscriber.State.should == "Active"
@@ -28,20 +29,21 @@ class SubscriberTest < Test::Unit::TestCase
       subscriber = CreateSend::Subscriber.get @auth, @list_id, email, true
       subscriber.EmailAddress.should == email
       subscriber.Name.should == "Subscriber One"
+      subscriber.MobileNumber.should == "123456000"
       subscriber.ConsentToTrack == "Yes"
       subscriber.ConsentToSendSms == "No"
     end
 
     should "add a subscriber without custom fields" do
       stub_post(@auth, "subscribers/#{@list_id}.json", "add_subscriber.json")
-      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", [], true, "Yes", "No"
+      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", "123456789", [], true, "Yes", "No"
       email_address.should == "subscriber@example.com"
     end
 
     should "add a subscriber with custom fields" do
       stub_post(@auth, "subscribers/#{@list_id}.json", "add_subscriber.json")
       custom_fields = [ { :Key => 'website', :Value => 'http://example.com/' } ]
-      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", custom_fields, true, "Yes", "Yes"
+      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", "123456789", custom_fields, true, "Yes", "Yes"
       email_address.should == "subscriber@example.com"
     end
 
@@ -50,7 +52,7 @@ class SubscriberTest < Test::Unit::TestCase
       custom_fields = [ { :Key => 'multioptionselectone', :Value => 'myoption' }, 
         { :Key => 'multioptionselectmany', :Value => 'firstoption' },
         { :Key => 'multioptionselectmany', :Value => 'secondoption' } ]
-      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", custom_fields, true, "Yes", "No"
+      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", "123456789", custom_fields, true, "Yes", "No"
       email_address.should == "subscriber@example.com"
     end
 
@@ -59,7 +61,7 @@ class SubscriberTest < Test::Unit::TestCase
       new_email = "new_email_address@example.com"
       stub_put(@auth, "subscribers/#{@list_id}.json?email=#{ERB::Util.url_encode(email)}", nil)
       custom_fields = [ { :Key => 'website', :Value => 'http://example.com/' } ]
-      @subscriber.update new_email, "Subscriber", custom_fields, true, "Yes", "No"
+      @subscriber.update new_email, "Subscriber", "123456", custom_fields, true, "Yes", "No"
       @subscriber.email_address.should == new_email
     end
 
@@ -68,7 +70,7 @@ class SubscriberTest < Test::Unit::TestCase
       new_email = "new_email_address@example.com"
       stub_put(@auth, "subscribers/#{@list_id}.json?email=#{ERB::Util.url_encode(email)}", nil)
       custom_fields = [ { :Key => 'website', :Value => '', :Clear => true } ]
-      @subscriber.update new_email, "Subscriber", custom_fields, true, "No", "Yes"
+      @subscriber.update new_email, "Subscriber", "123456", custom_fields, true, "No", "Yes"
       @subscriber.email_address.should == new_email
     end
     

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -22,25 +22,26 @@ class SubscriberTest < Test::Unit::TestCase
       subscriber.ReadsEmailWith.should == "Gmail"
     end
 
-    should "get a subscriber with track preference information" do
+    should "get a subscriber with track and sms preference information" do
       email = "subscriber@example.com"
-      stub_get(@auth, "subscribers/#{@list_id}.json?email=#{ERB::Util.url_encode(email)}&includetrackingpreference=true", "subscriber_details_with_track_pref.json")
+      stub_get(@auth, "subscribers/#{@list_id}.json?email=#{ERB::Util.url_encode(email)}&includetrackingpreference=true", "subscriber_details_with_track_and_sms_pref.json")
       subscriber = CreateSend::Subscriber.get @auth, @list_id, email, true
       subscriber.EmailAddress.should == email
       subscriber.Name.should == "Subscriber One"
       subscriber.ConsentToTrack == "Yes"
+      subscriber.ConsentToSendSms == "No"
     end
 
     should "add a subscriber without custom fields" do
       stub_post(@auth, "subscribers/#{@list_id}.json", "add_subscriber.json")
-      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", [], true, "Yes"
+      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", [], true, "Yes", "No"
       email_address.should == "subscriber@example.com"
     end
 
     should "add a subscriber with custom fields" do
       stub_post(@auth, "subscribers/#{@list_id}.json", "add_subscriber.json")
       custom_fields = [ { :Key => 'website', :Value => 'http://example.com/' } ]
-      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", custom_fields, true, "Yes"
+      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", custom_fields, true, "Yes", "Yes"
       email_address.should == "subscriber@example.com"
     end
 
@@ -49,7 +50,7 @@ class SubscriberTest < Test::Unit::TestCase
       custom_fields = [ { :Key => 'multioptionselectone', :Value => 'myoption' }, 
         { :Key => 'multioptionselectmany', :Value => 'firstoption' },
         { :Key => 'multioptionselectmany', :Value => 'secondoption' } ]
-      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", custom_fields, true, "Yes"
+      email_address = CreateSend::Subscriber.add @auth, @list_id, "subscriber@example.com", "Subscriber", custom_fields, true, "Yes", "No"
       email_address.should == "subscriber@example.com"
     end
 
@@ -58,7 +59,7 @@ class SubscriberTest < Test::Unit::TestCase
       new_email = "new_email_address@example.com"
       stub_put(@auth, "subscribers/#{@list_id}.json?email=#{ERB::Util.url_encode(email)}", nil)
       custom_fields = [ { :Key => 'website', :Value => 'http://example.com/' } ]
-      @subscriber.update new_email, "Subscriber", custom_fields, true, "Yes"
+      @subscriber.update new_email, "Subscriber", custom_fields, true, "Yes", "No"
       @subscriber.email_address.should == new_email
     end
 
@@ -67,7 +68,7 @@ class SubscriberTest < Test::Unit::TestCase
       new_email = "new_email_address@example.com"
       stub_put(@auth, "subscribers/#{@list_id}.json?email=#{ERB::Util.url_encode(email)}", nil)
       custom_fields = [ { :Key => 'website', :Value => '', :Clear => true } ]
-      @subscriber.update new_email, "Subscriber", custom_fields, true, "No"
+      @subscriber.update new_email, "Subscriber", custom_fields, true, "No", "Yes"
       @subscriber.email_address.should == new_email
     end
     


### PR DESCRIPTION
How to run specs: `bundle exec rake`
Test coverage: 100%
![Screen Shot 2023-10-19 at 11 28 32 am](https://github.com/campaignmonitor/createsend-ruby/assets/166879/d21a5474-11fc-4889-8358-ffb0b5beb73a)
