### PR TITLE
COM-676: Remove D&S makrup options from wrappers

### DIFF
--- a/lib/createsend/client.rb
+++ b/lib/createsend/client.rb
@@ -140,16 +140,14 @@ module CreateSend
 
     # Sets the PAYG billing settings for this client.
     def set_payg_billing(currency, can_purchase_credits, client_pays,
-      markup_percentage, markup_on_delivery=0, markup_per_recipient=0,
-      markup_on_design_spam_test=0)
+      markup_percentage, markup_on_delivery=0, markup_per_recipient=0)
       options = { :body => {
         :Currency => currency,
         :CanPurchaseCredits => can_purchase_credits,
         :ClientPays => client_pays,
         :MarkupPercentage => markup_percentage,
         :MarkupOnDelivery => markup_on_delivery,
-        :MarkupPerRecipient => markup_per_recipient,
-        :MarkupOnDesignSpamTest => markup_on_design_spam_test }.to_json }
+        :MarkupPerRecipient => markup_per_recipient }.to_json }
       put 'setpaygbilling', options
     end
 

--- a/test/fixtures/client_details.json
+++ b/test/fixtures/client_details.json
@@ -15,7 +15,6 @@
   "BillingDetails": {
      "CanPurchaseCredits": true,
      "Credits": 500,
-     "MarkupOnDesignSpamTest": 0.0,
      "ClientPays": true,
      "BaseRatePerRecipient": 1.0,
      "MarkupPerRecipient": 0.0,


### PR DESCRIPTION
As titled Note: Please use a Ruby version earlier than 3.2 to run all the tests ([update wiki doc](https://campaignmonitor.atlassian.net/wiki/spaces/~henrys/pages/256966721/How+to+test+Createsend-Ruby+wrapper+manually))
|client_test.rb -> set_payg_billing|
|-----------------------|
|![image](https://github.com/user-attachments/assets/54a1e534-ec51-45b4-9bd5-74f257957cac)|